### PR TITLE
Add shebang to deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 echo "Deploiement sur le serveur distant"
 ssh intranetv3 './deploy.sh'


### PR DESCRIPTION
Using `#!/usr/bin/env bash` enables portability between different *nix systems, as different systems will have their respective bash executables set up in different locations.
Using this specific shebang will actually run the first `bash` found in `PATH`