### PR TITLE
fix: required true on commentaire

### DIFF
--- a/src/Form/EvaluationType.php
+++ b/src/Form/EvaluationType.php
@@ -90,8 +90,11 @@ class EvaluationType extends AbstractType
                     'label' => 'label.commentaire',
                     'help' => 'help.commentaire_evaluation',
                     'disabled' => $autorise,
-                    'required' => false,
-                    'attr' => ['maxlength' => 255],
+                    'required' => true,
+                    'attr' => [
+                  'maxlength' => 255,
+                  'minlength' => 3
+                  ],
                 ])
             ->add('visible', YesNoType::class,
                 ['label' => 'label.evaluation.visible', 'help' => 'help.evaluation.visible'])


### PR DESCRIPTION
Le required true pour le champ commentaire permettra au professeur de ne pas oublier de faire un retour sur nos évaluations.