### PR TITLE
[Dashboard] Correction d'un lien utile

### DIFF
--- a/templates/default/index.html.twig
+++ b/templates/default/index.html.twig
@@ -141,7 +141,7 @@
                                 {{ settings('NOM_UNIVERSITE') }}</a>
                         </div>
                         <div class="col-md-3 col-sm-6 text-center">
-                            <a href="https://{{ settings('SITE_IUT') }}"
+                            <a href="{{ settings('SITE_IUT') }}"
                                target="_blank"><img
                                         src="{{ asset('upload/logo/' ~ settings('LOGO_IUT')) }}"
                                         alt="{{ settings('NOM_IUT') }}" class="img-rounded"


### PR DESCRIPTION
## Description
Correction d'un lien utile, un des liens en bas du dashboard est invalide (`https://https//www.iut-rcc.fr/`).