### PR TITLE
Disable debug dump in updateEvent method

### DIFF
--- a/src/Classes/Celcat/MyCelcat.php
+++ b/src/Classes/Celcat/MyCelcat.php
@@ -317,7 +317,7 @@ class MyCelcat
 
     private function updateEvent(EdtCelcat $intranet, EdtCelcat $celcat): void
     {
-        dump('Mise à jour de l\'événement ' . $intranet->getId());
+//        dump('Mise à jour de l\'événement ' . $intranet->getId());
         $this->log->addItem('Mise à jour de l\'événement ' . $intranet->getId(), 'info');
         // Mise à jour des données existantes de $intranet avec celles de $celcat
 


### PR DESCRIPTION
The dump statement in the updateEvent method was commented out to prevent unnecessary debug output. Logging is retained to ensure event updates are still properly tracked.