### PR TITLE
Enable debug output for event update in MyCelcat.php

### DIFF
--- a/src/Classes/Celcat/MyCelcat.php
+++ b/src/Classes/Celcat/MyCelcat.php
@@ -317,7 +317,7 @@ class MyCelcat
 
     private function updateEvent(EdtCelcat $intranet, EdtCelcat $celcat): void
     {
-//        dump('Mise à jour de l\'événement ' . $intranet->getId());
+        dump('Mise à jour de l\'événement ' . $intranet->getId());
         $this->log->addItem('Mise à jour de l\'événement ' . $intranet->getId(), 'info');
         // Mise à jour des données existantes de $intranet avec celles de $celcat
 


### PR DESCRIPTION
Reinstated a previously commented debug statement to facilitate logging and troubleshooting during event updates. This change ensures useful debugging information is available during the update process.