### PR TITLE
Add year filtering to Previsionnel queries

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -5,14 +5,9 @@
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
-      <jdbc-url>jdbc:mysql://127.0.0.1:8889/intranetv3</jdbc-url>
+      <jdbc-url>jdbc:mysql://10.5.1.245:3306/intranetv3</jdbc-url>
       <driver-properties>
         <property name="autoReconnect" value="true" />
-        <property name="zeroDateTimeBehavior" value="CONVERT_TO_NULL" />
-        <property name="tinyInt1isBit" value="false" />
-        <property name="characterEncoding" value="utf8" />
-        <property name="characterSetResults" value="utf8" />
-        <property name="yearIsDateType" value="false" />
       </driver-properties>
     </data-source>
   </component>

--- a/src/Command/EduSignEtudiantCommand.php
+++ b/src/Command/EduSignEtudiantCommand.php
@@ -47,7 +47,7 @@ class EduSignEtudiantCommand extends Command
         $keyEdusign = $input->getArgument('keyEduSign');
         $diplome = $this->diplomeRepository->findOneBy(['keyEduSign' => $keyEdusign]);
 
-        $this->updateEtudiant->changeSemestre($diplome, $keyEdusign);//boucler sur département pour chaque update (ou diplome)
+        $this->updateEtudiant->changeSemestre($diplome, $keyEdusign);
 
         $io->success('Etudiants mis à jour sur EduSign.');
 

--- a/src/Controller/transfertV4/TransfertPreviController.php
+++ b/src/Controller/transfertV4/TransfertPreviController.php
@@ -24,7 +24,7 @@ class TransfertPreviController extends AbstractController
         $page = $request->query->getInt('page', 1);
         $limit = $request->query->getInt('limit', 50);
 
-        $previsionnels = $previsionnelRepository->findByTypeMatiereWithPagination('matiere', $page, $limit);
+        $previsionnels = $previsionnelRepository->findByTypeMatiereWithPagination('matiere', $page, $limit, 2024);
 
         $tabPrevisionnels = [];
         foreach ($previsionnels as $previsionnel) {
@@ -66,7 +66,7 @@ class TransfertPreviController extends AbstractController
         $page = $request->query->getInt('page', 1);
         $limit = $request->query->getInt('limit', 50);
 
-        $previsionnels = $previsionnelRepository->findByTypeMatiereWithPagination('ressource', $page, $limit);
+        $previsionnels = $previsionnelRepository->findByTypeMatiereWithPagination('ressource', $page, $limit, 2024);
 
         foreach ($previsionnels as $previsionnel) {
             $annee = $anneeUniversitaireRepository->findOneBy(['annee' => $previsionnel->getAnnee()]);
@@ -108,7 +108,7 @@ class TransfertPreviController extends AbstractController
         $page = $request->query->getInt('page', 1);
         $limit = $request->query->getInt('limit', 50);
 
-        $previsionnels = $previsionnelRepository->findByTypeMatiereWithPagination('matiere', $page, $limit);
+        $previsionnels = $previsionnelRepository->findByTypeMatiereWithPagination('sae', $page, $limit, 2024);
 
         foreach ($previsionnels as $previsionnel) {
             $annee = $anneeUniversitaireRepository->findOneBy(['annee' => $previsionnel->getAnnee()]);

--- a/src/Repository/PrevisionnelRepository.php
+++ b/src/Repository/PrevisionnelRepository.php
@@ -9,6 +9,7 @@
 
 namespace App\Repository;
 
+use App\Entity\AnneeUniversitaire;
 use App\Entity\Previsionnel;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -30,10 +31,12 @@ class PrevisionnelRepository extends ServiceEntityRepository
         parent::__construct($registry, Previsionnel::class);
     }
 
-    public function findByTypeMatiereWithPagination(string $typeMatiere, int $page, int $limit)
+    public function findByTypeMatiereWithPagination(string $typeMatiere, int $page, int $limit, int $annee): array
     {
         $query = $this->createQueryBuilder('p')
             ->where('p.typeMatiere = :typeMatiere')
+            ->andWhere('p.annee = :annee')
+            ->setParameter('annee', $annee)
             ->setParameter('typeMatiere', $typeMatiere)
             ->setFirstResult(($page - 1) * $limit)
             ->setMaxResults($limit)


### PR DESCRIPTION
Updated the `findByTypeMatiereWithPagination` method in `PrevisionnelRepository` to include a mandatory year parameter for enhanced filtering. Adjusted calls in related controllers to pass the year value. Corrected database connection settings and made minor cleanups in other parts of the codebase.