### PR TITLE
fix: conditionne l'affichage du support en cas de problème

### DIFF
--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -29,7 +29,7 @@
             </twig:Alert>
         {% endif %}
         <p>Etudiants, personnels de l'Université et vacataires, connectez-vous avec l'authentification de
-           l'Université .</p>
+            l'Université .</p>
         <div class="d-grid col-12 d-block">
             <a href="{{ path('sso_cas') }}" class="btn btn-bold
            btn-primary">Connexion URCA</a>
@@ -69,10 +69,12 @@
                 <button class="btn btn-bold btn-primary" type="submit" name="connexionHorsUrca">{{ 'security.login.login'|trans }}</button>
             </div>
         </form>
-{#      indiquer le mail de contact en cas de problème      #}
-        <div class="text-center mt-3">
-            <p class="small">En cas de problème de connexion, contactez le support à cette adresse : <a href="mailto:intranet.iut-troyes@univ-reims.fr" class="small hover-primary">intranet.iut-troyes@univ-reims.fr</a></p>
-        </div>
+
+        {% if 'iut-troyes' in settings('SITE_IUT') %}
+            <div class="text-center mt-3">
+                <p class="small">En cas de problème de connexion, contactez le support à cette adresse : <a href="mailto:intranet.iut-troyes@univ-reims.fr" class="small hover-primary">intranet.iut-troyes@univ-reims.fr</a></p>
+            </div>
+        {% endif %}
     </div>
 {% endblock %}
 


### PR DESCRIPTION
Ajout d'une condition pour afficher l'adresse mail de support uniquement pour le site IUT Troyes. Cela améliore la personnalisation et évite l'affichage inutile d'informations non pertinentes sur d'autres sites.