### PR TITLE
fix: passage explicite de l'année universitaire dans les méthodes

### DIFF
--- a/src/Classes/EduSign/UpdateEdt.php
+++ b/src/Classes/EduSign/UpdateEdt.php
@@ -14,6 +14,7 @@ use App\Classes\EduSign\Adapter\IntranetEdtEduSignAdapter;
 use App\Classes\EduSign\Api\ApiCours;
 use App\Classes\Matieres\TypeMatiereManager;
 use App\DTO\EvenementEdt;
+use App\Entity\AnneeUniversitaire;
 use App\Entity\Diplome;
 use App\Entity\Semestre;
 use App\Repository\ApcReferentielRepository;
@@ -49,7 +50,7 @@ class UpdateEdt
     {
     }
 
-    public function update(?string $keyEduSign, ?int $opt, ?int $week): ?array
+    public function update(?string $keyEduSign, ?int $opt, ?int $week, ?AnneeUniversitaire $anneeUniversitaire): ?array
     {
         $diplomes = $keyEduSign === null
             ? $this->diplomeRepository->findAllWithEduSign()
@@ -64,13 +65,13 @@ class UpdateEdt
             foreach ($semestres as $semestre) {
                 $eventSemaine = $this->CalendrierRepository->findOneBy([
                     'semaineReelle' => $semaineReelle,
-                    'anneeUniversitaire' => $semestre->getAnneeUniversitaire()
+                    'anneeUniversitaire' => $anneeUniversitaire
                 ]);
                 $semaine = $eventSemaine->getSemaineFormation();
                 $matieresSemestre = $this->getMatieresSemestre($semestre);
                 $groupes = $this->groupeRepository->findBySemestre($semestre);
                 $edt = $this->edtManager->getPlanningSemestreSemaine(
-                    $semestre, $semaine, $semestre->getAnneeUniversitaire(), $matieresSemestre, $groupes
+                    $semestre, $semaine, $anneeUniversitaire, $matieresSemestre, $groupes
                 );
 
                 if ($edt->evenements) {


### PR DESCRIPTION
Ajout du paramètre `AnneeUniversitaire` aux méthodes `update` et `fixCourses` pour remplacer les appels implicites. Cela améliore la lisibilité et la gestion des années universitaires dans les traitements associés.